### PR TITLE
Fix rust crate publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: publish
-          args: --manifest-path build/rust/protos/Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }}
+          args: --manifest-path build/rust/protos/Cargo.toml --token ${{ secrets.CRATES_IO_TOKEN }} --frozen
       - uses: actions/setup-node@v3
         with:
           node-version: '18.x'


### PR DESCRIPTION
The protobuf-support crate has been updated to v3.3.0, but the docker image `rvolosatovs/protoc:latest` currently still builds against v3.2.0, causing the CI process to fail. Cargo by default will attempt to update dependencies unless `--frozen` is specified. I tested v3.3.0 against `rvolosatovs/protoc:development` and verified it works, but will wait to upgrade until the changes land on the `:latest` tag